### PR TITLE
chore: label attributes type hierarchy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
 
     steps:
       - name: Print env

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "python.envFile": "${workspaceFolder}/.env",
   "editor.formatOnSave": true,
 
+
   // ruff
   "[python]": {
     "editor.codeActionsOnSave": {
@@ -11,6 +12,7 @@
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
 
+  
   // unittest and pytest
   "python.testing.unittestArgs": ["-v", "-s", "./tests", "-p", "test_*.py"],
   "python.testing.pytestArgs": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ line-length = 119 # huggingface default
 
 [tool.ruff.isort]
 known-third-party = ["segments"]
-lines-after-imports = 2          # huggingface default
+lines-after-imports = 2 # huggingface default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-# pytest
+
 [tool.pytest.ini_options]
 addopts = "--cov=segments"
 testpaths = ["tests"]
 pythonpath = ["."]
 
-# mypy
+
 [tool.mypy]
 mypy_path = "src"
 plugins = ["pydantic.mypy"]
@@ -24,10 +24,11 @@ warn_unreachable = true
 warn_unused_configs = true
 no_implicit_reexport = true
 
-# ruff
+
 [tool.ruff]
 line-length = 119 # huggingface default
 
+
 [tool.ruff.isort]
 known-third-party = ["segments"]
-lines-after-imports = 2 # huggingface default
+lines-after-imports = 2          # huggingface default

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # general
-numpy >= 1.20, < 2 # include type stubs
+numpy >= 1.20 # include type stubs
 requests == 2.*
 Pillow >= 9.0
 tqdm == 4.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # general
-numpy>=1.20,<2 # include type stubs
-requests==2.*
-Pillow>=9.0
-tqdm==4.*
+numpy >= 1.20, < 2 # include type stubs
+requests == 2.*
+Pillow >= 9.0
+tqdm == 4.*
 
 # type hints
-typing_extensions==4.*
-pydantic==2.*,!=2.4.0 # bug in 2.4.0
-types-Pillow>=9.0
-types-requests==2.*
+typing_extensions == 4.*
+pydantic == 2.*, != 2.4.0 # bug in 2.4.0
+types-Pillow >= 9.0
+types-requests == 2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ requests == 2.*
 Pillow >= 9.0
 tqdm == 4.*
 
+
 # type hints
 typing_extensions == 4.*
 pydantic == 2.*, != 2.4.0 # bug in 2.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,8 +7,8 @@ mypy == 0.*
 
 # testing
 tox == 3.*
-pytest == 7.*
-pytest-cov == 4.*
+pytest == 8.*
+pytest-cov == 5.*
 pytest-dotenv == 0.*
 
 # general

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,6 +15,6 @@ mypy == 0.*
 
 # testing
 tox == 3.*
-pytest == 8.*
-pytest-cov == 5.*
+pytest == 7.*
+pytest-cov == 4.*
 pytest-dotenv == 0.*

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,14 +2,17 @@
 flynt == 1.*
 ruff == 0.*
 
+
 # type checking
 mypy == 0.*
+
 
 # testing
 tox == 3.*
 pytest == 8.*
 pytest-cov == 5.*
 pytest-dotenv == 0.*
+
 
 # general
 pycocotools == 2.*

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,17 +1,17 @@
 # code formatting
-flynt==1.*
-ruff==0.*
+flynt == 1.*
+ruff == 0.*
 
 # type checking
-mypy==0.*
+mypy == 0.*
 
 # testing
-tox==3.*
-pytest==7.*
-pytest-cov==4.*
-pytest-dotenv==0.*
+tox == 3.*
+pytest == 7.*
+pytest-cov == 4.*
+pytest-dotenv == 0.*
 
 # general
-pycocotools==2.*
-scikit-image==0.*
-opencv-python==4.*
+pycocotools == 2.*
+scikit-image == 0.*
+opencv-python == 4.*

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,9 @@
+# general
+pycocotools == 2.*
+scikit-image == 0.*
+opencv-python == 4.*
+
+
 # code formatting
 flynt == 1.*
 ruff == 0.*
@@ -12,9 +18,3 @@ tox == 3.*
 pytest == 8.*
 pytest-cov == 5.*
 pytest-dotenv == 0.*
-
-
-# general
-pycocotools == 2.*
-scikit-image == 0.*
-opencv-python == 4.*

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,9 +1,9 @@
 # documentation
-sphinx==4.*
-furo==2022.*
-myst_parser==0.*
-sphinx-autobuild==2021.*
-sphinx-copybutton==0.*
-sphinx_autodoc_typehints==1.*
-autodoc_pydantic==2.*
-datasets==2.*
+sphinx == 4.*
+furo == 2022.*
+myst_parser == 0.*
+sphinx-autobuild == 2021.*
+sphinx-copybutton == 0.*
+sphinx_autodoc_typehints == 1.*
+autodoc_pydantic == 2.*
+datasets == 2.*

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "docs": docs_requirements,
         "all": all_requirements,
     },  # Install with: pip install segments-ai[dev / docs / all]
-    python_requires=">=3.9",
+    python_requires=f">=3.{MIN_PYTHON3_VERSION}",
     classifiers=[
         "Development Status :: 5 - Production/Stable",  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
         "Intended Audience :: Developers",  # Define that your audience are developers

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from typing import List
 #############
 MAJOR, MINOR, PATCH = 1, 7, 6
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
+MIN_PYTHON3_VERSION, MAX_PYTHON3_VERSION = 9, 13
 
 
 ####################
@@ -66,24 +67,20 @@ setup(
         "dev": dev_requirements,
         "docs": docs_requirements,
         "all": all_requirements,
-    },  # Install with: pip install segments-ai[dev or docs]
-    python_requires=">=3.8",
+    },  # Install with: pip install segments-ai[dev / docs / all]
+    python_requires=">=3.9",
     classifiers=[
-        "Development Status :: 3 - Alpha",  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
+        "Development Status :: 5 - Production/Stable",  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
         "Intended Audience :: Developers",  # Define that your audience are developers
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: MIT License",  # Again, pick a license
+        "Typing :: Typed",
         "Programming Language :: Python :: 3",  # Specify which python versions that you want to support
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Typing :: Typed",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
-        "Operating System :: Unix",
-        "Operating System :: MacOS",
-    ],
+    ]
+    + [
+        f"Programming Language :: Python :: 3.{version}"
+        for version in range(MIN_PYTHON3_VERSION, MAX_PYTHON3_VERSION + 1)
+    ]
+    + [f"Operating System :: {os}" for os in ["Microsoft :: Windows", "POSIX", "Unix", "MacOS"]],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,17 +25,23 @@ def read_requirements(filename: str) -> List[str]:
             )
             if m is None:
                 return req
-            else:
-                return f"{m.group('name')} @ {req}"
+
+            return f"{m.group('name')} @ {req}"
 
         requirements = []
         for line in requirements_file:
             line = line.strip()
             if line.startswith("#") or len(line) <= 0:
                 continue
+
             requirements.append(fix_url_dependencies(line))
+
     return requirements
 
+
+dev_requirements = read_requirements("requirements_dev.txt")
+docs_requirements = read_requirements("requirements_docs.txt")
+all_requirements = dev_requirements + docs_requirements
 
 setup(
     name="segments-ai",  # How you named your package folder (MyLib)
@@ -57,8 +63,9 @@ setup(
     ],  # Keywords that define your package best
     install_requires=read_requirements("requirements.txt"),
     extras_require={
-        "dev": read_requirements("requirements_dev.txt"),
-        "docs": read_requirements("requirements_docs.txt"),
+        "dev": dev_requirements,
+        "docs": docs_requirements,
+        "all": all_requirements,
     },  # Install with: pip install segments-ai[dev or docs]
     python_requires=">=3.8",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -75,11 +75,11 @@ setup(
         "License :: OSI Approved :: MIT License",  # Again, pick a license
         "Programming Language :: Python :: 3",  # Specify which python versions that you want to support
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Typing :: Typed",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",

--- a/src/segments/client.py
+++ b/src/segments/client.py
@@ -120,10 +120,9 @@ def handle_exceptions(f: Callable[..., requests.Response]) -> Callable[..., Unio
             # Make string comparison case insensitive.
             text = e.response.text.lower()
             if "not found" in text or "does not exist" in text:
-                text += """\n
-Possible fixes:
+                text += """\n\nPossible fixes:
 - Check for typos in the dataset name, sample name, labelset name, etc.
-- Are you using the argument `dataset_name` -> Did you add the organization to the dataset name? E.g., `jane/flowers` instead of `flowers`.
+- Are you using the argument `dataset_name` -> Did you add the organization to the dataset name? E.g., `jane/flowers` instead of `flowers`.\n
 """
                 raise NotFoundError(message=text, cause=e)
             if "already exists" in text or "already have" in text:

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -291,13 +291,19 @@ class BaseLabelAttributes(BaseModel):
     image_attributes: Optional[ImageAttributes] = None
 
 
-class BaseFrame(BaseLabelAttributes):
+class BaseLabelAttributesFrame(BaseLabelAttributes):
     timestamp: Optional[Timestamp] = None
 
 
 class BaseSequenceLabelAttributes(BaseModel):
-    frames: List[BaseFrame]
+    frames: List[BaseLabelAttributesFrame]
     format_version: Optional[FormatVersion] = None
+
+
+class BaseMultiSensorSequenceLabelAttributes(BaseModel):
+    name: str
+    task_type: TaskType
+    attributes: BaseSequenceLabelAttributes
 
 
 # Image (sequence) segmentation
@@ -314,7 +320,7 @@ class ImageSegmentationLabelAttributes(BaseLabelAttributes):
     segmentation_bitmap: URL
 
 
-class ImageSequenceSegmentationFrame(BaseFrame, ImageSegmentationLabelAttributes):
+class ImageSequenceSegmentationFrame(BaseLabelAttributesFrame, ImageSegmentationLabelAttributes):
     annotations: List[ImageSequenceSegmentationAnnotation]
 
 
@@ -336,7 +342,7 @@ class ImageVectorLabelAttributes(BaseLabelAttributes):
     annotations: List[ImageVectorAnnotation]
 
 
-class ImageVectorFrame(BaseFrame, ImageVectorLabelAttributes):
+class ImageVectorFrame(BaseLabelAttributesFrame, ImageVectorLabelAttributes):
     annotations: List[ImageSequenceVectorAnnotation]
 
 
@@ -391,7 +397,7 @@ class PointcloudSegmentationLabelAttributes(BaseLabelAttributes):
     point_annotations: List[int]
 
 
-class PointcloudSegmentationFrame(BaseFrame, PointcloudSegmentationLabelAttributes):
+class PointcloudSegmentationFrame(BaseLabelAttributesFrame, PointcloudSegmentationLabelAttributes):
     annotations: List[PointcloudSequenceSegmentationAnnotation]
 
 
@@ -418,7 +424,7 @@ class PointcloudCuboidLabelAttributes(BaseLabelAttributes):
     annotations: List[PointcloudCuboidAnnotation]
 
 
-class PointcloudSequenceCuboidFrame(BaseFrame, PointcloudCuboidLabelAttributes):
+class PointcloudSequenceCuboidFrame(BaseLabelAttributesFrame, PointcloudCuboidLabelAttributes):
     annotations: List[PointcloudSequenceCuboidAnnotation]
 
 
@@ -440,7 +446,7 @@ class PointcloudVectorLabelAttributes(BaseLabelAttributes):
     annotations: List[PointcloudVectorAnnotation]
 
 
-class PointcloudSequenceVectorFrame(BaseFrame, PointcloudVectorLabelAttributes):
+class PointcloudSequenceVectorFrame(BaseLabelAttributesFrame, PointcloudVectorLabelAttributes):
     annotations: List[PointcloudSequenceVectorAnnotation]
 
 
@@ -449,15 +455,13 @@ class PointcloudSequenceVectorLabelAttributes(BaseSequenceLabelAttributes, Point
 
 
 # Multi-sensor sequence
-class MultiSensorImageSequenceVectorLabelAttributes(BaseModel):
-    name: str
+class MultiSensorImageSequenceVectorLabelAttributes(BaseMultiSensorSequenceLabelAttributes):
     task_type: Literal[TaskType.IMAGE_VECTOR_SEQUENCE]
     # TODO remove list and replace with `Optional[ImageSequenceVectorLabelAttributes] = None`
     attributes: Union[ImageSequenceVectorLabelAttributes, List]
 
 
-class MultiSensorPointcloudSequenceCuboidLabelAttributes(BaseModel):
-    name: str
+class MultiSensorPointcloudSequenceCuboidLabelAttributes(BaseMultiSensorSequenceLabelAttributes):
     task_type: Literal[TaskType.POINTCLOUD_CUBOID_SEQUENCE]
     # TODO remove list and replace with `Optional[PointcloudSequenceCuboidLabelAttributes] = None`
     attributes: Union[PointcloudSequenceCuboidLabelAttributes, List]
@@ -525,8 +529,27 @@ class LabelSummary(BaseModel):
 ##########
 # Sample #
 ##########
+# Base structure
+class BaseSampleAttributes(BaseModel):
+    pass
+
+
+class BaseSampleAttributesFrame(BaseSampleAttributes):
+    pass
+
+
+class BaseSequenceSampleAttributes(BaseSampleAttributes):
+    frames: List[BaseSampleAttributesFrame]
+
+
+class BaseMultiSensorSequenceSampleAttributes(BaseModel):
+    name: str
+    task_type: TaskType
+    attributes: BaseSequenceSampleAttributes
+
+
 # Image (sequence)
-class ImageSampleAttributes(BaseModel):
+class ImageSampleAttributes(BaseSampleAttributes):
     image: URL
 
 
@@ -535,7 +558,7 @@ class ImageFrame(ImageSampleAttributes):
     timestamp: Optional[Timestamp] = None
 
 
-class ImageSequenceSampleAttributes(BaseModel):
+class ImageSequenceSampleAttributes(BaseSequenceSampleAttributes):
     frames: List[ImageFrame]
 
 
@@ -580,7 +603,7 @@ class CalibratedImage(URL):
     rotation: Optional[float] = None
 
 
-class PointcloudSampleAttributes(BaseModel):
+class PointcloudSampleAttributes(BaseSampleAttributes):
     pcd: PCD
     images: Optional[List[CalibratedImage]] = None
     ego_pose: Optional[EgoPose] = None
@@ -590,19 +613,17 @@ class PointcloudSampleAttributes(BaseModel):
     bounds: Optional[Bounds] = None
 
 
-class PointcloudSequenceSampleAttributes(BaseModel):
+class PointcloudSequenceSampleAttributes(BaseSequenceSampleAttributes):
     frames: List[PointcloudSampleAttributes]
 
 
 # Multi-sensor sequence
-class MultiSensorImageSequenceSampleAttributes(BaseModel):
-    name: str
+class MultiSensorImageSequenceSampleAttributes(BaseMultiSensorSequenceSampleAttributes):
     task_type: Literal[TaskType.IMAGE_VECTOR_SEQUENCE]
     attributes: ImageSequenceSampleAttributes
 
 
-class MultiSensorPointcloudSequenceSampleAttributes(BaseModel):
-    name: str
+class MultiSensorPointcloudSequenceSampleAttributes(BaseMultiSensorSequenceSampleAttributes):
     task_type: Literal[TaskType.POINTCLOUD_CUBOID_SEQUENCE]
     attributes: PointcloudSequenceSampleAttributes
 

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -478,6 +478,7 @@ class MultiSensorLabelAttributes(BaseModel):
 class TextAnnotation(BaseAnnotation):
     start: int
     end: int
+    id: Optional[int] = None  # TODO add in frontend and remove here (is mandatory in `BaseAnnotation`)
 
 
 class TextLabelAttributes(BaseLabelAttributes):
@@ -488,19 +489,14 @@ class TextLabelAttributes(BaseLabelAttributes):
 LabelAttributes = Union[
     ImageVectorLabelAttributes,
     ImageSequenceVectorLabelAttributes,
-    
     ImageSegmentationLabelAttributes,
     ImageSequenceSegmentationLabelAttributes,
-    
     PointcloudCuboidLabelAttributes,
     PointcloudSequenceCuboidLabelAttributes,
-    
     PointcloudVectorLabelAttributes,
     PointcloudSequenceVectorLabelAttributes,
-    
     PointcloudSegmentationLabelAttributes,
     PointcloudSequenceSegmentationLabelAttributes,
-    
     MultiSensorLabelAttributes,
     TextLabelAttributes,
 ]

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -488,14 +488,19 @@ class TextLabelAttributes(BaseLabelAttributes):
 LabelAttributes = Union[
     ImageVectorLabelAttributes,
     ImageSequenceVectorLabelAttributes,
+    
     ImageSegmentationLabelAttributes,
     ImageSequenceSegmentationLabelAttributes,
+    
     PointcloudCuboidLabelAttributes,
     PointcloudSequenceCuboidLabelAttributes,
+    
     PointcloudVectorLabelAttributes,
     PointcloudSequenceVectorLabelAttributes,
+    
     PointcloudSegmentationLabelAttributes,
     PointcloudSequenceSegmentationLabelAttributes,
+    
     MultiSensorLabelAttributes,
     TextLabelAttributes,
 ]

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -300,29 +300,18 @@ class BaseSequenceLabelAttributes(BaseModel):
     format_version: Optional[FormatVersion] = None
 
 
-# Image segmentation
+# Image (sequence) segmentation
 class ImageSegmentationAnnotation(BaseAnnotation):
+    pass
+
+
+class ImageSequenceSegmentationAnnotation(BaseSequenceAnnotation, ImageSegmentationAnnotation):
     pass
 
 
 class ImageSegmentationLabelAttributes(BaseLabelAttributes):
     annotations: List[ImageSegmentationAnnotation]
     segmentation_bitmap: URL
-
-
-# Image vector
-class ImageVectorAnnotation(BaseAnnotation):
-    points: List[List[float]]
-    type: ImageVectorAnnotationType
-
-
-class ImageVectorLabelAttributes(BaseLabelAttributes):
-    annotations: List[ImageVectorAnnotation]
-
-
-# Image sequence segmentation
-class ImageSequenceSegmentationAnnotation(BaseSequenceAnnotation, ImageSegmentationAnnotation):
-    pass
 
 
 class ImageSequenceSegmentationFrame(BaseFrame, ImageSegmentationLabelAttributes):
@@ -333,9 +322,18 @@ class ImageSequenceSegmentationLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[ImageSequenceSegmentationFrame]
 
 
-# Image sequence vector
+# Image (sequence) vector
+class ImageVectorAnnotation(BaseAnnotation):
+    points: List[List[float]]
+    type: ImageVectorAnnotationType
+
+
 class ImageSequenceVectorAnnotation(BaseSequenceAnnotation, ImageVectorAnnotation):
     pass
+
+
+class ImageVectorLabelAttributes(BaseLabelAttributes):
+    annotations: List[ImageVectorAnnotation]
 
 
 class ImageVectorFrame(BaseFrame, ImageVectorLabelAttributes):
@@ -346,16 +344,7 @@ class ImageSequenceVectorLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[ImageVectorFrame]
 
 
-# Point cloud segmentation
-class PointcloudSegmentationAnnotation(BaseAnnotation):
-    pass
-
-
-class PointcloudSegmentationLabelAttributes(BaseLabelAttributes):
-    annotations: List[PointcloudSegmentationAnnotation]
-    point_annotations: List[int]
-
-
+# Point cloud (sequence) segmentation
 class XYZ(BaseModel):
     x: float
     y: float
@@ -389,33 +378,17 @@ class Distortion(BaseModel):
     coefficients: Union[FisheyeDistortionCoefficients, BrownConradyDistortionCoefficients]
 
 
-# Point cloud cuboid
-# https://stackoverflow.com/questions/51575931/class-inheritance-in-python-3-7-dataclasses
-class PointcloudCuboidAnnotation(BaseAnnotation):
-    position: XYZ
-    dimensions: XYZ
-    yaw: float
-    rotation: Optional[XYZW] = None
-    type: PointcloudCuboidAnnotationType
+class PointcloudSegmentationAnnotation(BaseAnnotation):
+    pass
 
 
-class PointcloudCuboidLabelAttributes(BaseLabelAttributes):
-    annotations: List[PointcloudCuboidAnnotation]
-
-
-# Point cloud vector
-class PointcloudVectorAnnotation(BaseAnnotation):
-    points: List[List[float]]
-    type: PointcloudVectorAnnotationType
-
-
-class PointcloudVectorLabelAttributes(BaseLabelAttributes):
-    annotations: List[PointcloudVectorAnnotation]
-
-
-# Point cloud sequence segmentation
 class PointcloudSequenceSegmentationAnnotation(BaseSequenceAnnotation, PointcloudSegmentationAnnotation):
     pass
+
+
+class PointcloudSegmentationLabelAttributes(BaseLabelAttributes):
+    annotations: List[PointcloudSegmentationAnnotation]
+    point_annotations: List[int]
 
 
 class PointcloudSegmentationFrame(BaseFrame, PointcloudSegmentationLabelAttributes):
@@ -428,9 +401,21 @@ class PointcloudSequenceSegmentationLabelAttributes(
     frames: List[PointcloudSegmentationFrame]
 
 
-# Point cloud sequence cuboid
+# Point cloud (sequence) cuboid
+class PointcloudCuboidAnnotation(BaseAnnotation):
+    position: XYZ
+    dimensions: XYZ
+    yaw: float
+    rotation: Optional[XYZW] = None
+    type: PointcloudCuboidAnnotationType
+
+
 class PointcloudSequenceCuboidAnnotation(BaseSequenceAnnotation, PointcloudCuboidAnnotation):
     pass
+
+
+class PointcloudCuboidLabelAttributes(BaseLabelAttributes):
+    annotations: List[PointcloudCuboidAnnotation]
 
 
 class PointcloudSequenceCuboidFrame(BaseFrame, PointcloudCuboidLabelAttributes):
@@ -441,9 +426,18 @@ class PointcloudSequenceCuboidLabelAttributes(BaseSequenceLabelAttributes, Point
     frames: List[PointcloudSequenceCuboidFrame]
 
 
-# Point cloud sequence vector
+# Point cloud (sequence) vector
+class PointcloudVectorAnnotation(BaseAnnotation):
+    points: List[List[float]]
+    type: PointcloudVectorAnnotationType
+
+
 class PointcloudSequenceVectorAnnotation(BaseSequenceAnnotation, PointcloudVectorAnnotation):
     pass
+
+
+class PointcloudVectorLabelAttributes(BaseLabelAttributes):
+    annotations: List[PointcloudVectorAnnotation]
 
 
 class PointcloudSequenceVectorFrame(BaseFrame, PointcloudVectorLabelAttributes):
@@ -454,14 +448,7 @@ class PointcloudSequenceVectorLabelAttributes(BaseSequenceLabelAttributes, Point
     frames: List[PointcloudSequenceVectorFrame]
 
 
-# Multi-sensor
-class MultiSensorPointcloudSequenceCuboidLabelAttributes(BaseModel):
-    name: str
-    task_type: Literal[TaskType.POINTCLOUD_CUBOID_SEQUENCE]
-    # TODO remove list and replace with `Optional[PointcloudSequenceCuboidLabelAttributes] = None`
-    attributes: Union[PointcloudSequenceCuboidLabelAttributes, List]
-
-
+# Multi-sensor sequence
 class MultiSensorImageSequenceVectorLabelAttributes(BaseModel):
     name: str
     task_type: Literal[TaskType.IMAGE_VECTOR_SEQUENCE]
@@ -469,11 +456,18 @@ class MultiSensorImageSequenceVectorLabelAttributes(BaseModel):
     attributes: Union[ImageSequenceVectorLabelAttributes, List]
 
 
+class MultiSensorPointcloudSequenceCuboidLabelAttributes(BaseModel):
+    name: str
+    task_type: Literal[TaskType.POINTCLOUD_CUBOID_SEQUENCE]
+    # TODO remove list and replace with `Optional[PointcloudSequenceCuboidLabelAttributes] = None`
+    attributes: Union[PointcloudSequenceCuboidLabelAttributes, List]
+
+
 class MultiSensorLabelAttributes(BaseModel):
     sensors: List[
         Union[
-            MultiSensorPointcloudSequenceCuboidLabelAttributes,
             MultiSensorImageSequenceVectorLabelAttributes,
+            MultiSensorPointcloudSequenceCuboidLabelAttributes,
         ],
     ]
 

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -273,76 +273,87 @@ class File(BaseModel):
 #########
 # Label #
 #########
-class Annotation(BaseModel):
+# Base structure
+class BaseAnnotation(BaseModel):
     id: int
     category_id: int
     attributes: Optional[ObjectAttributes] = None
+
+
+class BaseSequenceAnnotation(BaseAnnotation):
+    track_id: int
+    is_keyframe: bool = False
+
+
+class BaseLabelAttributes(BaseModel):
+    annotations: List[BaseAnnotation]
+    format_version: Optional[FormatVersion] = None
+    image_attributes: Optional[ImageAttributes] = None
+
+
+class BaseFrame(BaseLabelAttributes):
+    timestamp: Optional[Timestamp] = None
+
+
+class BaseSequenceLabelAttributes(BaseModel):
+    frames: List[BaseFrame]
+    format_version: Optional[FormatVersion] = None
 
 
 # Image segmentation
-class ImageSegmentationLabelAttributes(BaseModel):
-    annotations: List[Annotation]
+class ImageSegmentationAnnotation(BaseAnnotation):
+    pass
+
+
+class ImageSegmentationLabelAttributes(BaseLabelAttributes):
+    annotations: List[ImageSegmentationAnnotation]
     segmentation_bitmap: URL
-    image_attributes: Optional[ImageAttributes] = None
-    format_version: Optional[FormatVersion] = None
 
 
 # Image vector
-# https://stackoverflow.com/questions/51575931/class-inheritance-in-python-3-7-dataclasses
-class ImageVectorAnnotation(BaseModel):
-    id: int
-    category_id: int
+class ImageVectorAnnotation(BaseAnnotation):
     points: List[List[float]]
     type: ImageVectorAnnotationType
-    attributes: Optional[ObjectAttributes] = None
 
 
-class ImageVectorLabelAttributes(BaseModel):
+class ImageVectorLabelAttributes(BaseLabelAttributes):
     annotations: List[ImageVectorAnnotation]
-    format_version: Optional[FormatVersion] = None
-    image_attributes: Optional[ImageAttributes] = None
 
 
 # Image sequence segmentation
-class ImageSequenceSegmentationAnnotation(Annotation):
-    track_id: int
-    is_keyframe: bool = False
+class ImageSequenceSegmentationAnnotation(BaseSequenceAnnotation, ImageSegmentationAnnotation):
+    pass
 
 
-class ImageSequenceSegmentationFrame(ImageSegmentationLabelAttributes):
+class ImageSequenceSegmentationFrame(BaseFrame, ImageSegmentationLabelAttributes):
     annotations: List[ImageSequenceSegmentationAnnotation]
-    timestamp: Optional[Timestamp] = None
-    format_version: Optional[FormatVersion] = None
 
 
-class ImageSequenceSegmentationLabelAttributes(BaseModel):
+class ImageSequenceSegmentationLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[ImageSequenceSegmentationFrame]
-    format_version: Optional[FormatVersion] = None
 
 
 # Image sequence vector
-class ImageSequenceVectorAnnotation(ImageVectorAnnotation):
-    track_id: int
-    is_keyframe: bool = False
+class ImageSequenceVectorAnnotation(BaseSequenceAnnotation, ImageVectorAnnotation):
+    pass
 
 
-class ImageVectorFrame(ImageVectorLabelAttributes):
+class ImageVectorFrame(BaseFrame, ImageVectorLabelAttributes):
     annotations: List[ImageSequenceVectorAnnotation]
-    timestamp: Optional[Timestamp] = None
-    format_version: Optional[FormatVersion] = None
-    image_attributes: Optional[ImageAttributes] = None
 
 
-class ImageSequenceVectorLabelAttributes(BaseModel):
+class ImageSequenceVectorLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[ImageVectorFrame]
-    format_version: Optional[FormatVersion] = None
 
 
 # Point cloud segmentation
-class PointcloudSegmentationLabelAttributes(BaseModel):
-    annotations: List[Annotation]
+class PointcloudSegmentationAnnotation(BaseAnnotation):
+    pass
+
+
+class PointcloudSegmentationLabelAttributes(BaseLabelAttributes):
+    annotations: List[PointcloudSegmentationAnnotation]
     point_annotations: List[int]
-    format_version: Optional[FormatVersion] = None
 
 
 class XYZ(BaseModel):
@@ -380,87 +391,67 @@ class Distortion(BaseModel):
 
 # Point cloud cuboid
 # https://stackoverflow.com/questions/51575931/class-inheritance-in-python-3-7-dataclasses
-class PointcloudCuboidAnnotation(BaseModel):
-    id: int
-    category_id: int
+class PointcloudCuboidAnnotation(BaseAnnotation):
     position: XYZ
     dimensions: XYZ
     yaw: float
     rotation: Optional[XYZW] = None
     type: PointcloudCuboidAnnotationType
-    attributes: Optional[ObjectAttributes] = None
 
 
-class PointcloudCuboidLabelAttributes(BaseModel):
+class PointcloudCuboidLabelAttributes(BaseLabelAttributes):
     annotations: List[PointcloudCuboidAnnotation]
-    format_version: Optional[FormatVersion] = None
 
 
 # Point cloud vector
-class PointcloudVectorAnnotation(BaseModel):
-    id: int
-    category_id: int
+class PointcloudVectorAnnotation(BaseAnnotation):
     points: List[List[float]]
     type: PointcloudVectorAnnotationType
-    attributes: Optional[ObjectAttributes] = None
 
 
-class PointcloudVectorLabelAttributes(BaseModel):
+class PointcloudVectorLabelAttributes(BaseLabelAttributes):
     annotations: List[PointcloudVectorAnnotation]
-    format_version: Optional[FormatVersion] = None
 
 
 # Point cloud sequence segmentation
-class PointcloudSequenceSegmentationAnnotation(Annotation):
-    track_id: int
-    is_keyframe: bool = False
-    attributes: Optional[ObjectAttributes] = None
+class PointcloudSequenceSegmentationAnnotation(BaseSequenceAnnotation, PointcloudSegmentationAnnotation):
+    pass
 
 
-class PointcloudSegmentationFrame(PointcloudSegmentationLabelAttributes):
+class PointcloudSegmentationFrame(BaseFrame, PointcloudSegmentationLabelAttributes):
     annotations: List[PointcloudSequenceSegmentationAnnotation]
-    point_annotations: List[int]
-    timestamp: Optional[Timestamp] = None
-    format_version: Optional[FormatVersion] = None
 
 
-class PointcloudSequenceSegmentationLabelAttributes(BaseModel):
+class PointcloudSequenceSegmentationLabelAttributes(
+    BaseSequenceLabelAttributes, PointcloudSegmentationLabelAttributes
+):
     frames: List[PointcloudSegmentationFrame]
-    format_version: Optional[FormatVersion] = None
 
 
 # Point cloud sequence cuboid
-class PointcloudSequenceCuboidAnnotation(PointcloudCuboidAnnotation):
-    track_id: int
-    is_keyframe: bool = False
+class PointcloudSequenceCuboidAnnotation(BaseSequenceAnnotation, PointcloudCuboidAnnotation):
+    pass
 
 
-class PointcloudSequenceCuboidFrame(PointcloudCuboidLabelAttributes):
+class PointcloudSequenceCuboidFrame(BaseFrame, PointcloudCuboidLabelAttributes):
     annotations: List[PointcloudSequenceCuboidAnnotation]
-    timestamp: Optional[Timestamp] = None
-    format_version: Optional[FormatVersion] = None
 
 
-class PointcloudSequenceCuboidLabelAttributes(BaseModel):
+class PointcloudSequenceCuboidLabelAttributes(BaseSequenceLabelAttributes, PointcloudCuboidLabelAttributes):
     frames: List[PointcloudSequenceCuboidFrame]
-    format_version: Optional[FormatVersion] = None
 
 
 # Point cloud sequence vector
-class PointcloudSequenceVectorAnnotation(PointcloudVectorAnnotation):
-    track_id: int
-    is_keyframe: bool = False
+class PointcloudSequenceVectorAnnotation(BaseSequenceAnnotation, PointcloudVectorAnnotation):
+    pass
 
 
-class PointcloudSequenceVectorFrame(PointcloudVectorLabelAttributes):
+class PointcloudSequenceVectorFrame(BaseFrame, PointcloudVectorLabelAttributes):
     annotations: List[PointcloudSequenceVectorAnnotation]
-    format_version: Optional[FormatVersion] = None
-    timestamp: Optional[Timestamp] = None
 
 
-class PointcloudSequenceVectorLabelAttributes(BaseModel):
+class PointcloudSequenceVectorLabelAttributes(BaseSequenceLabelAttributes, PointcloudVectorLabelAttributes):
     frames: List[PointcloudSequenceVectorFrame]
-    format_version: Optional[FormatVersion] = None
 
 
 # Multi-sensor
@@ -488,15 +479,13 @@ class MultiSensorLabelAttributes(BaseModel):
 
 
 # Text
-class TextAnnotation(BaseModel):
+class TextAnnotation(BaseAnnotation):
     start: int
     end: int
-    category_id: int
 
 
-class TextLabelAttributes(BaseModel):
+class TextLabelAttributes(BaseLabelAttributes):
     annotations: List[TextAnnotation]
-    format_version: Optional[FormatVersion] = None
 
 
 # https://pydantic-docs.helpmanual.io/usage/types/#unions

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -401,9 +401,7 @@ class PointcloudSegmentationFrame(BaseLabelAttributesFrame, PointcloudSegmentati
     annotations: List[PointcloudSequenceSegmentationAnnotation]
 
 
-class PointcloudSequenceSegmentationLabelAttributes(
-    BaseSequenceLabelAttributes, PointcloudSegmentationLabelAttributes
-):
+class PointcloudSequenceSegmentationLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[PointcloudSegmentationFrame]
 
 
@@ -428,7 +426,7 @@ class PointcloudSequenceCuboidFrame(BaseLabelAttributesFrame, PointcloudCuboidLa
     annotations: List[PointcloudSequenceCuboidAnnotation]
 
 
-class PointcloudSequenceCuboidLabelAttributes(BaseSequenceLabelAttributes, PointcloudCuboidLabelAttributes):
+class PointcloudSequenceCuboidLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[PointcloudSequenceCuboidFrame]
 
 
@@ -450,7 +448,7 @@ class PointcloudSequenceVectorFrame(BaseLabelAttributesFrame, PointcloudVectorLa
     annotations: List[PointcloudSequenceVectorAnnotation]
 
 
-class PointcloudSequenceVectorLabelAttributes(BaseSequenceLabelAttributes, PointcloudVectorLabelAttributes):
+class PointcloudSequenceVectorLabelAttributes(BaseSequenceLabelAttributes):
     frames: List[PointcloudSequenceVectorFrame]
 
 
@@ -489,14 +487,14 @@ class TextLabelAttributes(BaseLabelAttributes):
 # https://pydantic-docs.helpmanual.io/usage/types/#unions
 LabelAttributes = Union[
     ImageVectorLabelAttributes,
-    ImageSegmentationLabelAttributes,
     ImageSequenceVectorLabelAttributes,
+    ImageSegmentationLabelAttributes,
     ImageSequenceSegmentationLabelAttributes,
     PointcloudCuboidLabelAttributes,
-    PointcloudVectorLabelAttributes,
-    PointcloudSegmentationLabelAttributes,
     PointcloudSequenceCuboidLabelAttributes,
+    PointcloudVectorLabelAttributes,
     PointcloudSequenceVectorLabelAttributes,
+    PointcloudSegmentationLabelAttributes,
     PointcloudSequenceSegmentationLabelAttributes,
     MultiSensorLabelAttributes,
     TextLabelAttributes,

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -525,12 +525,11 @@ class LabelSummary(BaseModel):
 ##########
 # Sample #
 ##########
-# Image
+# Image (sequence)
 class ImageSampleAttributes(BaseModel):
     image: URL
 
 
-# Image sequence
 class ImageFrame(ImageSampleAttributes):
     name: Optional[str] = None
     timestamp: Optional[Timestamp] = None
@@ -540,7 +539,7 @@ class ImageSequenceSampleAttributes(BaseModel):
     frames: List[ImageFrame]
 
 
-# Point cloud
+# Point cloud (sequence)
 class PCD(BaseModel):
     url: str
     signed_url: Optional[str] = None
@@ -591,29 +590,28 @@ class PointcloudSampleAttributes(BaseModel):
     bounds: Optional[Bounds] = None
 
 
-# Point cloud sequence
 class PointcloudSequenceSampleAttributes(BaseModel):
     frames: List[PointcloudSampleAttributes]
 
 
-# Multi-sensor
-class MultiSensorPointcloudSequenceSampleAttributes(BaseModel):
-    name: str
-    task_type: Literal[TaskType.POINTCLOUD_CUBOID_SEQUENCE]
-    attributes: PointcloudSequenceSampleAttributes
-
-
+# Multi-sensor sequence
 class MultiSensorImageSequenceSampleAttributes(BaseModel):
     name: str
     task_type: Literal[TaskType.IMAGE_VECTOR_SEQUENCE]
     attributes: ImageSequenceSampleAttributes
 
 
+class MultiSensorPointcloudSequenceSampleAttributes(BaseModel):
+    name: str
+    task_type: Literal[TaskType.POINTCLOUD_CUBOID_SEQUENCE]
+    attributes: PointcloudSequenceSampleAttributes
+
+
 class MultiSensorSampleAttributes(BaseModel):
     sensors: List[
         Union[
-            MultiSensorPointcloudSequenceSampleAttributes,
             MultiSensorImageSequenceSampleAttributes,
+            MultiSensorPointcloudSequenceSampleAttributes,
         ],
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-minversion = 3.8.0
-envlist = py38, py39, py310, py311, py312, flynt 
+minversion = 3.9.0
+envlist = py39, py310, py311, py312, py313, flynt 
 isolated_build = true
 
 [gh-actions]
 python =
-    3.8: py38, ruff, flynt
-    3.9: py39
+    3.9: py39, ruff, flynt
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 setenv =
@@ -29,7 +29,7 @@ commands =
     pytest --basetemp={envtmpdir}
 
 [testenv:mypy]
-basepython = python3.8
+basepython = python3.9
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands = mypy src tests setup.py docs/source/conf.py


### PR DESCRIPTION
### Tldr
This PR simplifies the label attributes type hierarchy. Fields that are not specific to, for example, a `CuboidLabelAttributes` are moved to the `BaseLabelAttributes` class.

### To do
- [ ] create separate smaller PRs