### PR TITLE
Fix pydantic validation error when vector annotations contain both cuboids and polygons

### DIFF
--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -404,7 +404,7 @@ class PointcloudVectorAnnotation(BaseModel):
 
 
 class PointcloudVectorLabelAttributes(BaseModel):
-    annotations: List[PointcloudVectorAnnotation]
+    annotations: List[Union[PointcloudVectorAnnotation, PointcloudCuboidAnnotation]]
     format_version: Optional[FormatVersion] = None
 
 


### PR DESCRIPTION
Pydantic did not expect elements of the "annotations" list in the sample attributes to contain both cuboid entries and the "classic" vector annotations. Fixed by adding a union in the pydantic model of `PointcloudVectorLabelAttributes`.
