### PR TITLE
Added signed url to image model

### DIFF
--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -200,6 +200,7 @@ Timestamp = Union[str, int, float]
 class URL(BaseModel):
     # TODO Remove optional (the backend does not return an URL when adding a release)
     url: Optional[str] = None
+    signed_url: Optional[str] = None
 
 
 class Release(BaseModel):


### PR DESCRIPTION
Signed url was not fetched for images for `client.get_sample(uuid, include_signed_url=True)`. 