### PR TITLE
Set default images array to empty instead of None

### DIFF
--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -591,7 +591,7 @@ class CalibratedImage(URL):
 
 class PointcloudSampleAttributes(BaseModel):
     pcd: PCD
-    images: Optional[List[CalibratedImage]] = None
+    images: List[CalibratedImage] = []
     ego_pose: Optional[EgoPose] = None
     default_z: Optional[float] = None
     name: Optional[str] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -900,11 +900,17 @@ class TestRelease(Test):
             wrong_name = "abcde"
             self.client.get_release(right_dataset_identifier, wrong_name)
 
+    # @unittest.skip("No 3D segmentation release available")
     def test_add_delete_release(self) -> None:
         name = "v0.4"
         description = "Test release description."
         for dataset in self.datasets:
             dataset_identifier = f"{self.owner}/{dataset}"
+            dataset_info = self.client.get_dataset(dataset_identifier)
+            if "pointcloud-segmentation" in dataset_info.task_type:
+                # Release files not supported for 3D segmentation
+                continue
+
             try:
                 # Add release
                 release = self.client.add_release(dataset_identifier, name, description)


### PR DESCRIPTION
This changes the `PointcloudSampleAttributes` type, so that `None` is no longer acceptable. De facto, this was already the case, since our platform expects an iterable, so `None` causes all sorts of trouble. 

Side effect of this change might be that some `client.get_samples` will cause pydantic validation errors. I'm not sure how we can let users recover from this issue themselves if they have a few bad attributes in their datasets.