### PR TITLE
Reduced tocdepth so individual methods aren't included

### DIFF
--- a/docs/source/client.md
+++ b/docs/source/client.md
@@ -1,3 +1,6 @@
+---
+tocdepth: 3
+---
 ```{seealso}
 Please visit our [docs](https://docs.segments.ai/) for more information on Segments.ai and visit the [setup page](https://sdkdocs.segments.ai/en/latest/setup.html) to learn how to install and setup the Segments.ai Python SDK.
 

--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -1,3 +1,6 @@
+---
+tocdepth: 3
+---
 ```{seealso}
 Please visit our [docs](https://docs.segments.ai/) for more information on Segments.ai and visit the [setup page](https://sdkdocs.segments.ai/en/latest/setup.html) to learn how to install and setup the Segments.ai Python SDK.
 


### PR DESCRIPTION
The documentation contains internal tables of contents for each file. Currently it looks cluttered, this fixes that by reducing how deep the local table of contents will go in a few files.

Before:
![image](https://github.com/user-attachments/assets/ed4b75e1-7302-4636-b0f4-6971dde6d596)

After:
![image](https://github.com/user-attachments/assets/79575f9a-ca59-449f-ae17-b59a6b8e198b)

