### PR TITLE
Fixed attributes being non optional for resource api updates

### DIFF
--- a/src/segments/resource_api.py
+++ b/src/segments/resource_api.py
@@ -489,11 +489,13 @@ class Sample(segments_typing.Sample, HasClient):
             :exc:`~segments.exceptions.NetworkError`: If the request is not valid or if the server experienced an error.
             :exc:`~segments.exceptions.TimeoutError`: If the request times out.
         """
-        attributes_model = validate_sample_attributes(attributes, self.dataset.task_type)
+        if attributes is not None:
+            attributes = validate_sample_attributes(attributes, self.dataset.task_type)
+
         return self._client.update_sample(
             self.uuid,
             name,
-            attributes_model,
+            attributes,
             metadata,
             priority,
             assigned_labeler,
@@ -548,7 +550,7 @@ class Sample(segments_typing.Sample, HasClient):
     def update_label(
         self,
         labelset: str,
-        attributes: Union[Dict[str, Any], segments_typing.LabelAttributes],
+        attributes: Optional[Union[Dict[str, Any], segments_typing.LabelAttributes]] = None,
         label_status: segments_typing.LabelStatus = segments_typing.LabelStatus.PRELABELED,
         score: Optional[float] = None,
         enable_compression: bool = True,
@@ -569,9 +571,11 @@ class Sample(segments_typing.Sample, HasClient):
             :exc:`~segments.exceptions.NetworkError`: If the request is not valid or if the server experienced an error.
             :exc:`~segments.exceptions.TimeoutError`: If the request times out.
         """
-        attributes_model = validate_label_attributes(attributes, self.dataset.task_type)
+        if attributes is not None:
+            attributes = validate_label_attributes(attributes, self.dataset.task_type)
+
         return self._client.update_label(
-            self.uuid, labelset, attributes_model, label_status, score, enable_compression
+            self.uuid, labelset, attributes, label_status, score, enable_compression
         )
 
     def delete_label(self, labelset: str) -> None:
@@ -623,7 +627,7 @@ class Label(segments_typing.Label, HasClient):
 
     def update(
         self,
-        attributes: Union[Dict[str, Any], segments_typing.LabelAttributes],
+        attributes: Optional[Union[Dict[str, Any], segments_typing.LabelAttributes]] = None,
         label_status: segments_typing.LabelStatus = segments_typing.LabelStatus.PRELABELED,
         score: Optional[float] = None,
         enable_compression: bool = True,
@@ -644,7 +648,9 @@ class Label(segments_typing.Label, HasClient):
             :exc:`~segments.exceptions.NetworkError`: If the request is not valid or if the server experienced an error.
             :exc:`~segments.exceptions.TimeoutError`: If the request times out.
         """
-        attributes = validate_label_attributes(attributes, self.label_type)
+        if attributes is not None:
+            attributes = validate_label_attributes(attributes, self.label_type)
+
         return self._client.update_label(
             self.sample_uuid, self.labelset, attributes, label_status, score, enable_compression
         )


### PR DESCRIPTION
When using the resource API, the attributes parameter for the `Sample.update` and `Label.update` methods were mandatory. This PR makes them optional, which aligns them with the client API.
