### PR TITLE
Allow unsetting assigned_reviewer/labeler

### DIFF
--- a/src/segments/client.py
+++ b/src/segments/client.py
@@ -57,6 +57,7 @@ from segments.typing import (
 from typing_extensions import Literal, get_args
 
 from .resource_api import Collaborator, Dataset, HasClient, Issue, Label, Labelset, Release, Sample
+from .sentinel import _NOT_ASSIGNED
 
 
 try:
@@ -1149,8 +1150,8 @@ class SegmentsClient:
         attributes: Optional[Union[Dict[str, Any], SampleAttributes]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         priority: Optional[float] = None,
-        assigned_labeler: Optional[str] = None,
-        assigned_reviewer: Optional[str] = None,
+        assigned_labeler: Optional[str] = _NOT_ASSIGNED,
+        assigned_reviewer: Optional[str] = _NOT_ASSIGNED,
         readme: Optional[str] = None,
         enable_compression: bool = True,
     ) -> Sample:
@@ -1216,10 +1217,10 @@ class SegmentsClient:
         if priority is not None:
             payload["priority"] = priority
 
-        if assigned_labeler is not None:
+        if assigned_labeler is not _NOT_ASSIGNED:
             payload["assigned_labeler"] = assigned_labeler
 
-        if assigned_reviewer is not None:
+        if assigned_reviewer is not _NOT_ASSIGNED:
             payload["assigned_reviewer"] = assigned_reviewer
 
         if readme is not None:

--- a/src/segments/resource_api.py
+++ b/src/segments/resource_api.py
@@ -6,6 +6,7 @@ import pydantic
 from segments.exceptions import InvalidModelError, MissingContextError
 
 from . import typing as segments_typing
+from .sentinel import _NOT_ASSIGNED
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -465,8 +466,8 @@ class Sample(segments_typing.Sample, HasClient):
         attributes: Optional[Union[Dict[str, Any], segments_typing.SampleAttributes]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         priority: Optional[float] = None,
-        assigned_labeler: Optional[str] = None,
-        assigned_reviewer: Optional[str] = None,
+        assigned_labeler: Optional[str] = _NOT_ASSIGNED,
+        assigned_reviewer: Optional[str] = _NOT_ASSIGNED,
         readme: Optional[str] = None,
         enable_compression: bool = True,
     ) -> Sample:

--- a/src/segments/sentinel.py
+++ b/src/segments/sentinel.py
@@ -1,0 +1,1 @@
+_NOT_ASSIGNED = object()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -279,6 +279,34 @@ class TestSample:
             wrong_uuid = "12345"
             self.client.delete_sample(wrong_uuid)
 
+    def test_unset_assigned(self, datasets, owner, add_update_sample_arguments, sample_attribute_types) -> None:
+        attributes = add_update_sample_arguments
+        name = "test_unset_assigned"
+
+        attributes_type = sample_attribute_types[0]
+        dataset = datasets[0]
+        dataset_identifier = f"{owner}/{dataset}"
+
+        if matched_samples := self.client.get_samples(dataset_identifier, name=name):
+            assert len(matched_samples) == 1, f"Multiple matches found for sample with name {name}"
+            self.client.delete_sample(matched_samples[0].uuid)
+
+        sample = self.client.add_sample(dataset_identifier, name, attributes[attributes_type], assigned_reviewer=owner, assigned_labeler=owner)
+        try:
+            assert sample.assigned_labeler == owner
+            assert sample.assigned_reviewer == owner
+
+            sample = self.client.update_sample(sample.uuid, assigned_labeler=None)
+
+            assert sample.assigned_labeler is None
+            assert sample.assigned_reviewer == owner
+            
+            sample = self.client.update_sample(sample.uuid, assigned_reviewer=None)
+
+            assert sample.assigned_reviewer is None
+        finally:
+            self.client.delete_sample(sample.uuid)
+
 
 #########
 # Label #

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -217,6 +217,36 @@ class TestSample:
                     time.sleep(TIME_INTERVAL)
                     sample.delete()
 
+    def test_unset_assigned(self, datasets, owner, add_update_sample_arguments, sample_attribute_types) -> None:
+        attributes = add_update_sample_arguments
+        name = "test_unset_assigned"
+
+        attributes_type = sample_attribute_types[0]
+        dataset_name = datasets[0]
+        dataset_identifier = f"{owner}/{dataset_name}"
+
+        dataset = self.client.get_dataset(dataset_identifier)
+
+        if matched_samples := dataset.get_samples(name=name):
+            assert len(matched_samples) == 1, f"Multiple matches found for sample with name {name}"
+            matched_samples[0].delete()
+
+        sample = dataset.add_sample(name, attributes[attributes_type], assigned_reviewer=owner, assigned_labeler=owner)
+        try:
+            assert sample.assigned_labeler == owner
+            assert sample.assigned_reviewer == owner
+
+            sample = sample.update(assigned_labeler=None)
+
+            assert sample.assigned_labeler is None
+            assert sample.assigned_reviewer == owner
+            
+            sample = sample.update(assigned_reviewer=None)
+
+            assert sample.assigned_reviewer is None
+        finally:
+            sample.delete()
+
 
 @pytest.mark.usefixtures("setup_class_client")
 class TestLabel:


### PR DESCRIPTION
This adds a sentinel object to the assigned_reviewer/labeler parameters in the sample update methods. With this change, we can detect the difference between a user explicitly providing an assigned_reviewer/labeler or them omitting it. With this change, users can unassign an assigned reviewer or labeller, where before a `None` was ommited from the payload.

