### PR TITLE
Fixed project name in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "segments"
+name = "segments-ai"
 authors = [
     {name = "Bert De Branderere", email = "bert@segments.ai"},
 ]


### PR DESCRIPTION
Small mistake in the `pyproject.toml` file: the name was the python module name, but it should correspond to the pypi name ("segments" vs "segments-ai")
