### PR TITLE
fix: rename setting confirm on commit to on submit in dataset type

### DIFF
--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -1106,7 +1106,7 @@ class Dataset(BaseModel):
     enable_same_dimensions_track_constraint: bool
     enable_3d_region_of_interest: bool
     enable_3d_cuboid_rotation: Optional[bool] = None
-    enable_confirm_on_commit: Optional[bool] = None
+    enable_confirm_on_submit: Optional[bool] = None
     enable_interpolation: bool
     use_timestamps_for_interpolation: bool
     enable_object_linking: bool


### PR DESCRIPTION
- `enable_confirm_on_commit`: naming used for the update argument
- `enable_confirm_on_submit`: naming used in Segments product, so should be in the Dataset type to read it