### PR TITLE
feat: support image-segmentation-sequence sensor in multisensor

### DIFF
--- a/docs/source/types.md
+++ b/docs/source/types.md
@@ -270,6 +270,10 @@ Please visit our [docs](https://docs.segments.ai/) for more information on Segme
 .. autopydantic_model:: segments.typing.MultiSensorImageSequenceVectorLabelAttributes
 ```
 
+```{eval-rst}
+.. autopydantic_model:: segments.typing.MultiSensorImageSequenceSegmentationLabelAttributes
+```
+
 ### Links
 
 ```{eval-rst}

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -416,6 +416,7 @@ class ImageSequenceSegmentationAnnotation(Annotation):
 
 class ImageSequenceSegmentationFrame(ImageSegmentationLabelAttributes):
     annotations: List[ImageSequenceSegmentationAnnotation]
+    segmentation_bitmap: Optional[URL] = None
     timestamp: Optional[Timestamp] = None
     format_version: Optional[FormatVersion] = None
 
@@ -635,6 +636,13 @@ class MultiSensorImageSequenceVectorLabelAttributes(BaseModel):
     attributes: Union[ImageSequenceVectorLabelAttributes, List]
 
 
+class MultiSensorImageSequenceSegmentationLabelAttributes(BaseModel):
+    name: str
+    task_type: Literal[TaskType.IMAGE_SEGMENTATION_SEQUENCE]
+    # TODO remove list and replace with `Optional[ImageSequenceSegmentationLabelAttributes] = None`
+    attributes: Union[ImageSequenceSegmentationLabelAttributes, List]
+
+
 class MultiSensorPointcloudSequenceVectorLabelAttributes(BaseModel):
     name: str
     task_type: Literal[TaskType.POINTCLOUD_VECTOR_SEQUENCE]
@@ -649,6 +657,7 @@ class MultiSensorLabelAttributes(BaseModel):
                 MultiSensorPointcloudSequenceCuboidLabelAttributes,
                 MultiSensorPointcloudSequenceVectorLabelAttributes,
                 MultiSensorImageSequenceVectorLabelAttributes,
+                MultiSensorImageSequenceSegmentationLabelAttributes,
             ],
             pydantic.Field(discriminator="task_type"),
         ]
@@ -781,7 +790,10 @@ class MultiSensorPointcloudSequenceSampleAttributes(BaseModel):
 
 class MultiSensorImageSequenceSampleAttributes(BaseModel):
     name: str
-    task_type: Literal[TaskType.IMAGE_VECTOR_SEQUENCE]
+    task_type: Union[
+        Literal[TaskType.IMAGE_VECTOR_SEQUENCE],
+        Literal[TaskType.IMAGE_SEGMENTATION_SEQUENCE],
+    ]
     attributes: ImageSequenceSampleAttributes
 
 


### PR DESCRIPTION
## Summary
- Add `MultiSensorImageSequenceSegmentationLabelAttributes` and include it in the discriminated `MultiSensorLabelAttributes.sensors` union so 2D image segmentation sequences can be used as a sensor in `multisensor-sequence` datasets.
- Broaden `MultiSensorImageSequenceSampleAttributes.task_type` to accept both `image-vector-sequence` and `image-segmentation-sequence` (both share `ImageSequenceSampleAttributes`).
- Document the new label model in `docs/source/types.md`.

## Test plan
- [ ] Validate a `MultiSensorSampleAttributes` payload containing an `image-segmentation-sequence` sensor
- [ ] Validate a `MultiSensorLabelAttributes` payload containing an `image-segmentation-sequence` sensor
- [ ] Confirm existing `image-vector-sequence` and pointcloud sensor variants still validate unchanged
- [ ] Build docs and confirm the new autopydantic entry renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)