### PR TITLE
feat: allow sdk to also set link_category_restrictions

### DIFF
--- a/src/segments/client.py
+++ b/src/segments/client.py
@@ -434,6 +434,8 @@ class SegmentsClient:
         archived: bool = False,
         enable_3d_region_of_interest: bool = False,
         region_of_interest: Optional[dict[str, Any]] = None,
+        enable_object_linking: Optional[bool] = None,
+        enable_object_link_category_restrictions: Optional[bool] = None,
     ) -> Dataset:
         """Add a dataset.
 
@@ -498,6 +500,8 @@ class SegmentsClient:
             archived: Whether the dataset is archived. Defaults to :obj:`False`.
             enable_3d_region_of_interest: Enable region of interest for point cloud datasets. Defaults to :obj:`False`.
             region_of_interest: Region of interest configuration. Defaults to :obj:`None`.
+            enable_object_linking: Enable object linking. Defaults to :obj:`None`, which lets the server decide.
+            enable_object_link_category_restrictions: Restrict object linking to the categories allowlisted in each category's ``link_category_restrictions``. Ignored when object linking is disabled. Note that a category with an empty or missing allowlist can then not be linked to anything. Defaults to :obj:`None`, which lets the server decide.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the task attributes fails.
@@ -556,6 +560,12 @@ class SegmentsClient:
         if region_of_interest is not None:
             payload["region_of_interest"] = region_of_interest
 
+        if enable_object_linking is not None:
+            payload["enable_object_linking"] = enable_object_linking
+
+        if enable_object_link_category_restrictions is not None:
+            payload["enable_object_link_category_restrictions"] = enable_object_link_category_restrictions
+
         endpoint = f"/organizations/{organization}/datasets/" if organization is not None else "/user/datasets/"
 
         r = self._post(endpoint, data=payload, model=Dataset)
@@ -587,6 +597,7 @@ class SegmentsClient:
         region_of_interest: Optional[dict[str, Any]] = None,
         use_timestamps_for_interpolation: Optional[bool] = None,
         enable_object_linking: Optional[bool] = None,
+        enable_object_link_category_restrictions: Optional[bool] = None,
     ) -> Dataset:
         """Update a dataset.
 
@@ -621,6 +632,7 @@ class SegmentsClient:
             region_of_interest: Region of interest configuration. Defaults to :obj:`None`.
             use_timestamps_for_interpolation: Use timestamps for interpolation in sequence datasets. Defaults to :obj:`None`.
             enable_object_linking: Enable object linking (beta). Defaults to :obj:`None`.
+            enable_object_link_category_restrictions: Restrict object linking to the categories allowlisted in each category's ``link_category_restrictions``. Ignored when object linking is disabled. Note that a category with an empty or missing allowlist can then not be linked to anything. Defaults to :obj:`None`.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the dataset fails.
@@ -710,6 +722,9 @@ class SegmentsClient:
 
         if enable_object_linking is not None:
             payload["enable_object_linking"] = enable_object_linking
+
+        if enable_object_link_category_restrictions is not None:
+            payload["enable_object_link_category_restrictions"] = enable_object_link_category_restrictions
 
         r = self._patch(f"/datasets/{dataset_identifier}/", data=payload, model=Dataset)
         # logger.info(f"Updated {dataset_identifier}")

--- a/src/segments/resource_api.py
+++ b/src/segments/resource_api.py
@@ -162,6 +162,7 @@ class Dataset(segments_typing.Dataset, HasClient):
         region_of_interest: Optional[dict[str, Any]] = None,
         use_timestamps_for_interpolation: Optional[bool] = None,
         enable_object_linking: Optional[bool] = None,
+        enable_object_link_category_restrictions: Optional[bool] = None,
     ) -> Dataset:
         """Updates the dataset, see :meth:`segments.client.SegmentsClient.update_dataset` for more details.
 
@@ -188,6 +189,7 @@ class Dataset(segments_typing.Dataset, HasClient):
             region_of_interest: Region of interest configuration. Defaults to :obj:`None`.
             use_timestamps_for_interpolation: Use timestamps for interpolation in sequence datasets. Defaults to :obj:`None`.
             enable_object_linking: Enable object linking (beta). Defaults to :obj:`None`.
+            enable_object_link_category_restrictions: Restrict object linking to the categories allowlisted in each category's ``link_category_restrictions``. Ignored when object linking is disabled. Note that a category with an empty or missing allowlist can then not be linked to anything. Defaults to :obj:`None`.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the dataset fails.
@@ -220,6 +222,7 @@ class Dataset(segments_typing.Dataset, HasClient):
             region_of_interest,
             use_timestamps_for_interpolation,
             enable_object_linking,
+            enable_object_link_category_restrictions,
         )
 
     def get_samples(

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -1036,6 +1036,7 @@ class TaskAttributeCategory(BaseModel):
     dimensions: Optional[PartialXYZ] = None
     model_config = ConfigDict(extra="allow")
     link_attributes: Optional[List[TaskLinkAttribute]] = None
+    link_category_restrictions: Optional[List[int]] = None
 
 
 class IntersectingCuboidsRule(BaseModel):
@@ -1129,6 +1130,7 @@ class Dataset(BaseModel):
     enable_interpolation: bool
     use_timestamps_for_interpolation: bool
     enable_object_linking: bool
+    enable_object_link_category_restrictions: bool = None
     task_type: TaskType
     # task_readme: str
     label_stats: LabelStats

--- a/tests/fixtures/payloads.py
+++ b/tests/fixtures/payloads.py
@@ -42,6 +42,13 @@ def add_update_dataset_arguments(owner):
                             "default_value": False,
                         },
                     ],
+                    "link_category_restrictions": [2],
+                },
+                {
+                    "name": "test_link_target",
+                    "id": 2,
+                    "color": [0, 0, 0, 0],
+                    "link_category_restrictions": [1],
                 },
             ],
             "warning_rules": [
@@ -70,6 +77,8 @@ def add_update_dataset_arguments(owner):
         "enable_skip_labeling": True,
         "enable_skip_reviewing": True,
         "enable_ratings": True,
+        "enable_object_linking": True,
+        "enable_object_link_category_restrictions": True,
         "organization": owner,
     }
     return arguments

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,25 @@
+from segments.typing import TaskAttributes
+
+
+def test_link_category_restrictions_round_trip() -> None:
+    """The allowlist must survive the validate + dump path that add_dataset/update_dataset use."""
+    task_attributes = TaskAttributes.model_validate(
+        {
+            "format_version": "0.1",
+            "categories": [
+                {"name": "car", "id": 1, "link_category_restrictions": [2]},
+                {"name": "wheel", "id": 2, "link_category_restrictions": []},
+                {"name": "tree", "id": 3},
+            ],
+        }
+    )
+
+    assert task_attributes.categories[0].link_category_restrictions == [2]
+    assert task_attributes.categories[1].link_category_restrictions == []
+    # Omitted stays omitted rather than becoming an empty allowlist, which would mean "link to nothing".
+    assert task_attributes.categories[2].link_category_restrictions is None
+
+    dumped = task_attributes.model_dump(mode="json", exclude_unset=True)
+    assert dumped["categories"][0]["link_category_restrictions"] == [2]
+    assert dumped["categories"][1]["link_category_restrictions"] == []
+    assert "link_category_restrictions" not in dumped["categories"][2]


### PR DESCRIPTION
Allow SDK to configure object linking options on a dataset.