### PR TITLE
feat: add transform_to_ego_coordinates option to get_label

### DIFF
--- a/docs/source/utils.md
+++ b/docs/source/utils.md
@@ -60,6 +60,12 @@ Please visit our [docs](https://docs.segments.ai/) for more information on Segme
 .. autofunction:: segments.utils.cuboid_to_segmentation
 ```
 
+### Transform a point cloud label from world to ego coordinates
+
+```{eval-rst}
+.. autofunction:: segments.utils.transform_label_to_ego_coordinates
+```
+
 ### Turn a numpy array into a point cloud
 
 ```{eval-rst}

--- a/src/segments/client.py
+++ b/src/segments/client.py
@@ -1376,7 +1376,12 @@ class SegmentsClient:
     ##########
     # Labels #
     ##########
-    def get_label(self, sample_uuid: str, labelset: str = "ground-truth") -> Label:
+    def get_label(
+        self,
+        sample_uuid: str,
+        labelset: str = "ground-truth",
+        transform_to_ego_coordinates: bool = False,
+    ) -> Label:
         """Get a label.
 
         Note:
@@ -1391,6 +1396,7 @@ class SegmentsClient:
         Args:
             sample_uuid: The sample uuid.
             labelset: The labelset this label belongs to. Defaults to ``ground-truth``.
+            transform_to_ego_coordinates: Whether to transform the annotations of a point cloud label from world to ego coordinates, using the ego poses in the sample. This makes an additional request to fetch the sample. See :func:`segments.utils.transform_label_to_ego_coordinates` for more details. Defaults to :obj:`False`.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the label fails.
@@ -1398,11 +1404,19 @@ class SegmentsClient:
             :exc:`~segments.exceptions.NotFoundError`: If the sample or labelset is not found or if the sample is unlabeled.
             :exc:`~segments.exceptions.NetworkError`: If the request is not valid or if the server experienced an error.
             :exc:`~segments.exceptions.TimeoutError`: If the request times out.
+            :exc:`ValueError`: If ``transform_to_ego_coordinates`` is :obj:`True` and the sample is not a point cloud (sequence) or multi-sensor sample.
         """
 
         r = self._get(f"/labels/{sample_uuid}/{labelset}/", model=Label)
+        label = cast(Label, r)
 
-        return cast(Label, r)
+        if transform_to_ego_coordinates:
+            from segments.utils import transform_label_to_ego_coordinates
+
+            sample = self.get_sample(sample_uuid)
+            label = transform_label_to_ego_coordinates(sample, label)
+
+        return label
 
     def add_label(
         self,

--- a/src/segments/resource_api.py
+++ b/src/segments/resource_api.py
@@ -546,11 +546,14 @@ class Sample(segments_typing.Sample, HasClient):
             enable_compression,
         )
 
-    def get_label(self, labelset: Optional[str] = "ground-truth") -> Label:
+    def get_label(
+        self, labelset: Optional[str] = "ground-truth", transform_to_ego_coordinates: bool = False
+    ) -> Label:
         """Gets the label of this sample. See :meth:`segments.client.SegmentsClient.get_label` for more details.
 
         Args:
             labelset: The labelset this label belongs to. Defaults to ``ground-truth``.
+            transform_to_ego_coordinates: Whether to transform the annotations of a point cloud label from world to ego coordinates, using the ego poses in the sample. Defaults to :obj:`False`.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the label fails.
@@ -559,7 +562,7 @@ class Sample(segments_typing.Sample, HasClient):
             :exc:`~segments.exceptions.NetworkError`: If the request is not valid or if the server experienced an error.
             :exc:`~segments.exceptions.TimeoutError`: If the request times out.
         """
-        return self._client.get_label(self.uuid, labelset)
+        return self._client.get_label(self.uuid, labelset, transform_to_ego_coordinates)
 
     def add_label(
         self,

--- a/src/segments/utils.py
+++ b/src/segments/utils.py
@@ -27,10 +27,14 @@ from segments.typing import (
     Label,
     MultiSensorLabelAttributes,
     MultiSensorPointcloudSequenceCuboidLabelAttributes,
+    MultiSensorPointcloudSequenceSampleAttributes,
     MultiSensorSampleAttributes,
+    PointcloudCuboidAnnotation,
     PointcloudCuboidLabelAttributes,
+    PointcloudSampleAttributes,
     PointcloudSequenceCuboidLabelAttributes,
     PointcloudSequenceSampleAttributes,
+    PointcloudVectorAnnotation,
     Sample,
     TaskType,
     Velocity,
@@ -1281,5 +1285,159 @@ def add_kinematics_to_label(
 
                 if acceleration is not None:
                     annotation.acceleration = acceleration
+
+    return label_copy
+
+
+def _quaternion_normalized(q: XYZW) -> npt.NDArray[np.float64]:
+    array = np.array([q.qx, q.qy, q.qz, q.qw], dtype=np.float64)
+    norm = np.linalg.norm(array)
+    if norm == 0:
+        raise ValueError("Invalid ego pose heading: quaternion has zero norm.")
+    return array / norm
+
+
+def _quaternion_rotation_matrix(q: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    x, y, z, w = q
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+
+
+def _quaternion_multiply(q1: npt.NDArray[np.float64], q2: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    x1, y1, z1, w1 = q1
+    x2, y2, z2, w2 = q2
+    return np.array(
+        [
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        ]
+    )
+
+
+def _quaternion_yaw(q: npt.NDArray[np.float64]) -> float:
+    x, y, z, w = q
+    return float(np.arctan2(2 * (w * z + x * y), 1 - 2 * (y * y + z * z)))
+
+
+def _transform_annotations_to_ego(annotations: List[Any], ego_pose: EgoPose) -> None:
+    """Transform cuboid and vector annotations from world to ego coordinates, in place."""
+    ego_quaternion = _quaternion_normalized(ego_pose.heading)
+    ego_quaternion_inverse = ego_quaternion * np.array([-1.0, -1.0, -1.0, 1.0])
+    rotation = _quaternion_rotation_matrix(ego_quaternion)
+    translation = np.array([ego_pose.position.x, ego_pose.position.y, ego_pose.position.z])
+    ego_yaw = _quaternion_yaw(ego_quaternion)
+
+    for annotation in annotations:
+        if isinstance(annotation, PointcloudCuboidAnnotation):
+            position = np.array([annotation.position.x, annotation.position.y, annotation.position.z])
+            position = rotation.T @ (position - translation)
+            annotation.position.x, annotation.position.y, annotation.position.z = (
+                float(position[0]),
+                float(position[1]),
+                float(position[2]),
+            )
+            annotation.yaw = annotation.yaw - ego_yaw
+            if annotation.rotation is not None:
+                annotation_quaternion = _quaternion_multiply(
+                    ego_quaternion_inverse, _quaternion_normalized(annotation.rotation)
+                )
+                annotation.rotation = XYZW(
+                    qx=float(annotation_quaternion[0]),
+                    qy=float(annotation_quaternion[1]),
+                    qz=float(annotation_quaternion[2]),
+                    qw=float(annotation_quaternion[3]),
+                )
+        elif isinstance(annotation, PointcloudVectorAnnotation):
+            annotation.points = [
+                list(map(float, rotation.T @ (np.array(point) - translation))) if len(point) == 3 else point
+                for point in annotation.points
+            ]
+
+
+def transform_label_to_ego_coordinates(sample: Sample, label: Label) -> Label:
+    """Transform point cloud label annotations from world to ego coordinates using the ego poses in the sample.
+
+    Cuboid annotations get their ``position``, ``yaw`` and ``rotation`` transformed; vector annotations get their ``points`` transformed. Segmentation annotations have no coordinates and are returned unchanged. Frames without an ego pose are left in world coordinates and a warning is logged.
+
+    Args:
+        sample: A point cloud (sequence) or multi-sensor Sample object containing the ego poses.
+        label: A Label object belonging to the sample.
+
+    Returns:
+        A copy of the label with the annotations transformed to ego coordinates.
+
+    Raises:
+        ValueError: If the label sample UUID does not match the sample UUID.
+        ValueError: If the sample is not a point cloud (sequence) or multi-sensor sample.
+
+    Example:
+
+      .. code-block:: python
+
+        # pip install segments-ai
+        from segments import SegmentsClient
+        from segments.utils import transform_label_to_ego_coordinates
+
+        client = SegmentsClient('YOUR_API_KEY')
+        sample = client.get_sample(sample_uuid)
+        label = client.get_label(sample_uuid)
+        transformed_label = transform_label_to_ego_coordinates(sample, label)
+    """
+
+    if label.sample_uuid != sample.uuid:
+        raise ValueError("Label sample UUID does not match sample UUID.")
+
+    label_copy = copy.deepcopy(label)
+    if label_copy.attributes is None:
+        return label_copy
+
+    frames_without_ego_pose = 0
+
+    def transform_frames(label_attributes: Any, sample_frames: List[PointcloudSampleAttributes]) -> None:
+        nonlocal frames_without_ego_pose
+        for frame_index, frame in enumerate(label_attributes.frames):
+            ego_pose = sample_frames[frame_index].ego_pose if frame_index < len(sample_frames) else None
+            if ego_pose is None:
+                frames_without_ego_pose += 1
+            else:
+                _transform_annotations_to_ego(frame.annotations, ego_pose)
+
+    if isinstance(sample.attributes, PointcloudSampleAttributes):
+        if sample.attributes.ego_pose is None:
+            frames_without_ego_pose += 1
+        elif hasattr(label_copy.attributes, "annotations"):
+            _transform_annotations_to_ego(label_copy.attributes.annotations, sample.attributes.ego_pose)
+    elif isinstance(sample.attributes, PointcloudSequenceSampleAttributes):
+        if hasattr(label_copy.attributes, "frames"):
+            transform_frames(label_copy.attributes, sample.attributes.frames)
+    elif isinstance(sample.attributes, MultiSensorSampleAttributes):
+        sample_sensors = {
+            sensor.name: sensor
+            for sensor in sample.attributes.sensors
+            if isinstance(sensor, MultiSensorPointcloudSequenceSampleAttributes)
+        }
+        if isinstance(label_copy.attributes, MultiSensorLabelAttributes):
+            for label_sensor in label_copy.attributes.sensors:
+                sample_sensor = sample_sensors.get(label_sensor.name)
+                if sample_sensor is not None and hasattr(label_sensor.attributes, "frames"):
+                    transform_frames(label_sensor.attributes, sample_sensor.attributes.frames)
+    else:
+        raise ValueError(
+            "Sample must be a point cloud, point cloud sequence or multi-sensor sample "
+            "to transform its label to ego coordinates."
+        )
+
+    if frames_without_ego_pose:
+        logger.warning(
+            f"{frames_without_ego_pose} frame(s) have no ego pose: "
+            "their annotations are left in world coordinates."
+        )
 
     return label_copy

--- a/tests/test_ego_transform.py
+++ b/tests/test_ego_transform.py
@@ -1,0 +1,268 @@
+import math
+
+import pytest
+from segments.typing import (
+    PCD,
+    XYZ,
+    XYZW,
+    EgoPose,
+    Label,
+    LabelStatus,
+    PCDType,
+    PointcloudCuboidAnnotation,
+    PointcloudCuboidLabelAttributes,
+    PointcloudSampleAttributes,
+    PointcloudSequenceCuboidAnnotation,
+    PointcloudSequenceCuboidFrame,
+    PointcloudSequenceCuboidLabelAttributes,
+    PointcloudSequenceSampleAttributes,
+    PointcloudVectorAnnotation,
+    PointcloudVectorLabelAttributes,
+    Sample,
+    TaskType,
+)
+from segments.utils import transform_label_to_ego_coordinates
+
+
+SAMPLE_UUID = "602a3eec-a61c-4a77-9fcc-3037ce5e9606"
+
+IDENTITY_HEADING = XYZW(qx=0, qy=0, qz=0, qw=1)
+# 90 degrees around the z-axis
+YAW_90_HEADING = XYZW(qx=0, qy=0, qz=math.sin(math.pi / 4), qw=math.cos(math.pi / 4))
+
+
+def make_sample(attributes) -> Sample:
+    return Sample(
+        uuid=SAMPLE_UUID,
+        name="sample",
+        attributes=attributes,
+        metadata={},
+        created_at="2024-01-01",
+        created_by="tester",
+        priority=0,
+    )
+
+
+def make_label(attributes, label_type: TaskType) -> Label:
+    return Label(
+        sample_uuid=SAMPLE_UUID,
+        label_type=label_type,
+        label_status=LabelStatus.LABELED,
+        labelset="ground-truth",
+        attributes=attributes,
+        created_at="2024-01-01",
+        created_by="tester",
+        updated_at="2024-01-01",
+    )
+
+
+def make_pointcloud_attributes(ego_pose) -> PointcloudSampleAttributes:
+    return PointcloudSampleAttributes(pcd=PCD(url="https://example.com/a.pcd", type=PCDType.PCD), ego_pose=ego_pose)
+
+
+def make_cuboid(position: XYZ, yaw: float = 0.0, rotation=None) -> PointcloudCuboidAnnotation:
+    return PointcloudCuboidAnnotation(
+        id=1,
+        category_id=1,
+        position=position,
+        dimensions=XYZ(x=1, y=1, z=1),
+        yaw=yaw,
+        rotation=rotation,
+        type="cuboid",
+    )
+
+
+def assert_xyz_almost_equal(position: XYZ, expected) -> None:
+    assert (position.x, position.y, position.z) == pytest.approx(expected)
+
+
+def test_translation_only() -> None:
+    sample = make_sample(make_pointcloud_attributes(EgoPose(position=XYZ(x=1, y=2, z=3), heading=IDENTITY_HEADING)))
+    label = make_label(
+        PointcloudCuboidLabelAttributes(annotations=[make_cuboid(XYZ(x=2, y=2, z=3))]),
+        TaskType.POINTCLOUD_CUBOID,
+    )
+
+    transformed = transform_label_to_ego_coordinates(sample, label)
+
+    assert_xyz_almost_equal(transformed.attributes.annotations[0].position, (1, 0, 0))
+    # the original label is untouched
+    assert_xyz_almost_equal(label.attributes.annotations[0].position, (2, 2, 3))
+
+
+def test_rotation_and_yaw() -> None:
+    sample = make_sample(make_pointcloud_attributes(EgoPose(position=XYZ(x=0, y=0, z=0), heading=YAW_90_HEADING)))
+    label = make_label(
+        PointcloudCuboidLabelAttributes(annotations=[make_cuboid(XYZ(x=1, y=0, z=0), yaw=0.0, rotation=IDENTITY_HEADING)]),
+        TaskType.POINTCLOUD_CUBOID,
+    )
+
+    transformed = transform_label_to_ego_coordinates(sample, label)
+    annotation = transformed.attributes.annotations[0]
+
+    assert_xyz_almost_equal(annotation.position, (0, -1, 0))
+    assert annotation.yaw == pytest.approx(-math.pi / 2)
+    assert (annotation.rotation.qx, annotation.rotation.qy) == pytest.approx((0, 0))
+    assert annotation.rotation.qz == pytest.approx(-math.sin(math.pi / 4))
+    assert annotation.rotation.qw == pytest.approx(math.cos(math.pi / 4))
+
+
+def test_vector_points() -> None:
+    sample = make_sample(make_pointcloud_attributes(EgoPose(position=XYZ(x=1, y=0, z=0), heading=YAW_90_HEADING)))
+    label = make_label(
+        PointcloudVectorLabelAttributes(
+            annotations=[
+                PointcloudVectorAnnotation(
+                    id=1, category_id=1, points=[[1, 0, 0], [2, 0, 0]], type="polyline"
+                )
+            ]
+        ),
+        TaskType.POINTCLOUD_VECTOR,
+    )
+
+    transformed = transform_label_to_ego_coordinates(sample, label)
+
+    points = transformed.attributes.annotations[0].points
+    assert points[0] == pytest.approx((0, 0, 0))
+    assert points[1] == pytest.approx((0, -1, 0))
+
+
+def test_sequence_with_missing_ego_pose(caplog) -> None:
+    sample = make_sample(
+        PointcloudSequenceSampleAttributes(
+            frames=[
+                make_pointcloud_attributes(EgoPose(position=XYZ(x=1, y=0, z=0), heading=IDENTITY_HEADING)),
+                make_pointcloud_attributes(None),
+            ]
+        )
+    )
+
+    def make_frame(position: XYZ) -> PointcloudSequenceCuboidFrame:
+        return PointcloudSequenceCuboidFrame(
+            annotations=[
+                PointcloudSequenceCuboidAnnotation(
+                    id=1,
+                    category_id=1,
+                    position=position,
+                    dimensions=XYZ(x=1, y=1, z=1),
+                    yaw=0.0,
+                    type="cuboid",
+                    track_id=1,
+                )
+            ]
+        )
+
+    label = make_label(
+        PointcloudSequenceCuboidLabelAttributes(frames=[make_frame(XYZ(x=2, y=0, z=0)), make_frame(XYZ(x=3, y=0, z=0))]),
+        TaskType.POINTCLOUD_CUBOID_SEQUENCE,
+    )
+
+    transformed = transform_label_to_ego_coordinates(sample, label)
+
+    assert_xyz_almost_equal(transformed.attributes.frames[0].annotations[0].position, (1, 0, 0))
+    # frame without an ego pose is left in world coordinates
+    assert_xyz_almost_equal(transformed.attributes.frames[1].annotations[0].position, (3, 0, 0))
+    assert "no ego pose" in caplog.text
+
+
+def test_uuid_mismatch_raises() -> None:
+    sample = make_sample(make_pointcloud_attributes(None))
+    label = make_label(
+        PointcloudCuboidLabelAttributes(annotations=[make_cuboid(XYZ(x=0, y=0, z=0))]),
+        TaskType.POINTCLOUD_CUBOID,
+    )
+    label.sample_uuid = "other-uuid"
+
+    with pytest.raises(ValueError, match="does not match"):
+        transform_label_to_ego_coordinates(sample, label)
+
+
+def test_multisensor() -> None:
+    from segments.typing import (
+        BasePointcloudSequenceCuboidLabelAttributes,
+        MultiSensorLabelAttributes,
+        MultiSensorPointcloudSequenceCuboidLabelAttributes,
+        MultiSensorPointcloudSequenceSampleAttributes,
+        MultiSensorSampleAttributes,
+    )
+
+    sample = make_sample(
+        MultiSensorSampleAttributes(
+            sensors=[
+                MultiSensorPointcloudSequenceSampleAttributes(
+                    name="lidar",
+                    task_type=TaskType.POINTCLOUD_CUBOID_SEQUENCE,
+                    attributes=PointcloudSequenceSampleAttributes(
+                        frames=[make_pointcloud_attributes(EgoPose(position=XYZ(x=1, y=0, z=0), heading=IDENTITY_HEADING))]
+                    ),
+                )
+            ]
+        )
+    )
+    label = make_label(
+        MultiSensorLabelAttributes(
+            sensors=[
+                MultiSensorPointcloudSequenceCuboidLabelAttributes(
+                    name="lidar",
+                    task_type=TaskType.POINTCLOUD_CUBOID_SEQUENCE,
+                    attributes=BasePointcloudSequenceCuboidLabelAttributes(
+                        frames=[
+                            PointcloudSequenceCuboidFrame(
+                                annotations=[
+                                    PointcloudSequenceCuboidAnnotation(
+                                        id=1,
+                                        category_id=1,
+                                        position=XYZ(x=3, y=0, z=0),
+                                        dimensions=XYZ(x=1, y=1, z=1),
+                                        yaw=0.0,
+                                        type="cuboid",
+                                        track_id=1,
+                                    )
+                                ]
+                            )
+                        ]
+                    ),
+                )
+            ]
+        ),
+        TaskType.MULTISENSOR_SEQUENCE,
+    )
+
+    transformed = transform_label_to_ego_coordinates(sample, label)
+
+    annotation = transformed.attributes.sensors[0].attributes.frames[0].annotations[0]
+    assert_xyz_almost_equal(annotation.position, (2, 0, 0))
+
+
+def test_client_get_label_transform(monkeypatch) -> None:
+    from segments.client import SegmentsClient
+
+    sample = make_sample(make_pointcloud_attributes(EgoPose(position=XYZ(x=1, y=2, z=3), heading=IDENTITY_HEADING)))
+    label = make_label(
+        PointcloudCuboidLabelAttributes(annotations=[make_cuboid(XYZ(x=2, y=2, z=3))]),
+        TaskType.POINTCLOUD_CUBOID,
+    )
+
+    # bypass __init__, which verifies the API key over the network
+    client = SegmentsClient.__new__(SegmentsClient)
+    monkeypatch.setattr(client, "_get", lambda *args, **kwargs: label)
+    monkeypatch.setattr(client, "get_sample", lambda uuid: sample)
+
+    untransformed = client.get_label(SAMPLE_UUID)
+    assert_xyz_almost_equal(untransformed.attributes.annotations[0].position, (2, 2, 3))
+
+    transformed = client.get_label(SAMPLE_UUID, transform_to_ego_coordinates=True)
+    assert_xyz_almost_equal(transformed.attributes.annotations[0].position, (1, 0, 0))
+
+
+def test_non_pointcloud_sample_raises() -> None:
+    from segments.typing import ImageSampleAttributes, URL
+
+    sample = make_sample(ImageSampleAttributes(image=URL(url="https://example.com/a.jpg")))
+    label = make_label(
+        PointcloudCuboidLabelAttributes(annotations=[make_cuboid(XYZ(x=0, y=0, z=0))]),
+        TaskType.POINTCLOUD_CUBOID,
+    )
+
+    with pytest.raises(ValueError, match="point cloud"):
+        transform_label_to_ego_coordinates(sample, label)


### PR DESCRIPTION
## Summary

Adds an optional `transform_to_ego_coordinates` argument (default `False`) to `client.get_label()` that transforms point cloud label annotations from world to ego coordinates, using the ego poses present in the sample. When set, `get_label` makes an additional `get_sample` request to fetch the ego poses.

The transform itself is implemented as a standalone util, `segments.utils.transform_label_to_ego_coordinates(sample, label)`, which can also be used directly on an already-fetched sample/label pair.

## Details

- **Transform** (world → ego): `p_ego = R⁻¹ · (p_world − t)` with `t`/`R` from the ego pose position and heading quaternion.
  - Cuboid annotations: `position` is transformed, ego yaw is subtracted from `yaw`, and `rotation` (when present) becomes `q_ego⁻¹ ⊗ q_annotation` (full rigid transform).
  - Vector annotations: each 3D point in `points` is transformed.
  - Segmentation annotations have no coordinates and pass through unchanged.
- **Supported sample types**: single-frame pointcloud (one ego pose), pointcloud sequence (label frames matched to sample frames by index), and multi-sensor (pointcloud sensors matched by name). Other sample types raise `ValueError`.
- Frames without an ego pose are left in world coordinates and a summary warning is logged.
- The util returns a transformed copy; the input label is never mutated.
- Quaternion math is implemented with plain numpy, so no dependency on the optional `pyquaternion`/`open3d` extras.
- The new arg is also plumbed through `Sample.get_label()` in the resource API, and the util is added to the docs.

## Tests

New offline unit tests in `tests/test_ego_transform.py` (no API credentials needed, unlike the existing integration tests): translation, rotation/yaw/quaternion, vector points, sequence with missing ego pose, multi-sensor, uuid mismatch, non-pointcloud sample, and the `get_label` plumbing with a mocked client. All pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)