### PR TITLE
feat: enables extrapolation for cuboids

### DIFF
--- a/src/segments/client.py
+++ b/src/segments/client.py
@@ -436,6 +436,7 @@ class SegmentsClient:
         region_of_interest: Optional[dict[str, Any]] = None,
         enable_object_linking: Optional[bool] = None,
         enable_object_link_category_restrictions: Optional[bool] = None,
+        enable_extrapolation: Optional[bool] = None,
     ) -> Dataset:
         """Add a dataset.
 
@@ -502,6 +503,7 @@ class SegmentsClient:
             region_of_interest: Region of interest configuration. Defaults to :obj:`None`.
             enable_object_linking: Enable object linking. Defaults to :obj:`None`, which lets the server decide.
             enable_object_link_category_restrictions: Restrict object linking to the categories allowlisted in each category's ``link_category_restrictions``. Ignored when object linking is disabled. Note that a category with an empty or missing allowlist can then not be linked to anything. Defaults to :obj:`None`, which lets the server decide.
+            enable_extrapolation: Enable linear extrapolation of a 3D cuboid's position past its last keyframe in sequence datasets. Ignored for non-cuboid datasets. Defaults to :obj:`None`, which lets the server decide (currently defaults to :obj:`False`).
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the task attributes fails.
@@ -566,6 +568,9 @@ class SegmentsClient:
         if enable_object_link_category_restrictions is not None:
             payload["enable_object_link_category_restrictions"] = enable_object_link_category_restrictions
 
+        if enable_extrapolation is not None:
+            payload["enable_extrapolation"] = enable_extrapolation
+
         endpoint = f"/organizations/{organization}/datasets/" if organization is not None else "/user/datasets/"
 
         r = self._post(endpoint, data=payload, model=Dataset)
@@ -598,6 +603,7 @@ class SegmentsClient:
         use_timestamps_for_interpolation: Optional[bool] = None,
         enable_object_linking: Optional[bool] = None,
         enable_object_link_category_restrictions: Optional[bool] = None,
+        enable_extrapolation: Optional[bool] = None,
     ) -> Dataset:
         """Update a dataset.
 
@@ -633,6 +639,7 @@ class SegmentsClient:
             use_timestamps_for_interpolation: Use timestamps for interpolation in sequence datasets. Defaults to :obj:`None`.
             enable_object_linking: Enable object linking (beta). Defaults to :obj:`None`.
             enable_object_link_category_restrictions: Restrict object linking to the categories allowlisted in each category's ``link_category_restrictions``. Ignored when object linking is disabled. Note that a category with an empty or missing allowlist can then not be linked to anything. Defaults to :obj:`None`.
+            enable_extrapolation: Enable linear extrapolation of a 3D cuboid's position past its last keyframe in sequence datasets. Ignored for non-cuboid datasets. Defaults to :obj:`None`, which leaves the dataset's current setting unchanged.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the dataset fails.
@@ -725,6 +732,9 @@ class SegmentsClient:
 
         if enable_object_link_category_restrictions is not None:
             payload["enable_object_link_category_restrictions"] = enable_object_link_category_restrictions
+
+        if enable_extrapolation is not None:
+            payload["enable_extrapolation"] = enable_extrapolation
 
         r = self._patch(f"/datasets/{dataset_identifier}/", data=payload, model=Dataset)
         # logger.info(f"Updated {dataset_identifier}")

--- a/src/segments/resource_api.py
+++ b/src/segments/resource_api.py
@@ -163,6 +163,7 @@ class Dataset(segments_typing.Dataset, HasClient):
         use_timestamps_for_interpolation: Optional[bool] = None,
         enable_object_linking: Optional[bool] = None,
         enable_object_link_category_restrictions: Optional[bool] = None,
+        enable_extrapolation: Optional[bool] = None,
     ) -> Dataset:
         """Updates the dataset, see :meth:`segments.client.SegmentsClient.update_dataset` for more details.
 
@@ -190,6 +191,7 @@ class Dataset(segments_typing.Dataset, HasClient):
             use_timestamps_for_interpolation: Use timestamps for interpolation in sequence datasets. Defaults to :obj:`None`.
             enable_object_linking: Enable object linking (beta). Defaults to :obj:`None`.
             enable_object_link_category_restrictions: Restrict object linking to the categories allowlisted in each category's ``link_category_restrictions``. Ignored when object linking is disabled. Note that a category with an empty or missing allowlist can then not be linked to anything. Defaults to :obj:`None`.
+            enable_extrapolation: Enable linear extrapolation of a 3D cuboid's position past its last keyframe in sequence datasets. Ignored for non-cuboid datasets. Defaults to :obj:`None`, which leaves the dataset's current setting unchanged.
 
         Raises:
             :exc:`~segments.exceptions.ValidationError`: If validation of the dataset fails.
@@ -223,6 +225,7 @@ class Dataset(segments_typing.Dataset, HasClient):
             use_timestamps_for_interpolation,
             enable_object_linking,
             enable_object_link_category_restrictions,
+            enable_extrapolation,
         )
 
     def get_samples(

--- a/src/segments/typing.py
+++ b/src/segments/typing.py
@@ -1131,6 +1131,7 @@ class Dataset(BaseModel):
     use_timestamps_for_interpolation: bool
     enable_object_linking: bool
     enable_object_link_category_restrictions: bool = None
+    enable_extrapolation: bool = None
     task_type: TaskType
     # task_readme: str
     label_stats: LabelStats


### PR DESCRIPTION
Adds the extrapolation field for datasets in the SDK, to upload with the default set to None.